### PR TITLE
use pre-processed install.rdf like other system add-ons

### DIFF
--- a/build-includes.txt
+++ b/build-includes.txt
@@ -1,6 +1,6 @@
 bootstrap.js
 data
-install.rdf
+install.rdf.in
 lib
 moz.build
 node_modules/jexl/lib

--- a/install.rdf.in
+++ b/install.rdf.in
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+#filter substitution
+
+<RDF xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:em="http://www.mozilla.org/2004/em-rdf#">
+  <Description about="urn:mozilla:install-manifest">
+    <em:id>shield-recipe-client@mozilla.org</em:id>
+    <em:type>2</em:type>
+    <em:bootstrap>true</em:bootstrap>
+    <em:unpack>false</em:unpack>
+    <em:version>1.0.0</em:version>
+    <em:name>Shield Recipe Client</em:name>
+    <em:description>Client to download and run recipes for SHIELD, Heartbeat, etc.</em:description>
+    <em:multiprocessCompatible>true</em:multiprocessCompatible>
+
+    <em:targetApplication>
+      <Description>
+        <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
+        <em:minVersion>@MOZ_APP_VERSION@</em:minVersion>
+        <em:maxVersion>@MOZ_APP_MAXVERSION@</em:maxVersion>
+      </Description>
+    </em:targetApplication>
+  </Description>
+</RDF>

--- a/moz.build
+++ b/moz.build
@@ -9,7 +9,10 @@ DEFINES['MOZ_APP_MAXVERSION'] = CONFIG['MOZ_APP_MAXVERSION']
 
 FINAL_TARGET_FILES.features['shield-recipe-client@mozilla.org'] += [
   'bootstrap.js',
-  'install.rdf',
+]
+
+FINAL_TARGET_PP_FILES.features['shield-recipe-client@mozilla.org'] += [
+  'install.rdf.in'
 ]
 
 BROWSER_CHROME_MANIFESTS += [


### PR DESCRIPTION
The other built-in system add-ons in mozilla-central use a pre-processed install manifest to set the min/max version for only the Firefox that they ship with.

This means you have both an `install.rdf` (for running standalone from the git repo) and a `install.rdf.in` to keep in sync, sorry :(

I'm sure there's a clever way to reduce the redundancy ;)